### PR TITLE
Switch to using ReloadManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Version.cpp
 *.sln
 .vs*
 TootTallyMultiplayer.zip
+.idea

--- a/MultiplayerCore/MultiplayerController.cs
+++ b/MultiplayerCore/MultiplayerController.cs
@@ -445,9 +445,21 @@ namespace TootTallyMultiplayer
                             FileHelper.ExtractZipToDirectory(source, destination);
 
                             FileHelper.DeleteFile(downloadDir, fileName);
-                            TootTallyCore.Plugin.Instance.ReloadTracks();
-                            SelectSongFromTrackref(_savedTrackRef);
-                            SendUserState(UserState.NotReady);
+                            TootTallyCore.Plugin.Instance.reloadManager.ReloadAll(
+                                new ProgressCallbacks
+                                {
+                                    onComplete = () => 
+                                    {
+                                        SelectSongFromTrackref(_savedTrackRef);
+                                        SendUserState(UserState.NotReady); 
+                                    },
+                                    onError = (error) =>
+                                    {
+                                        Plugin.LogError(error.StackTrace);
+                                        TootTallyNotifManager.DisplayNotif("Download failed. Unexpected error occured.");
+                                    },
+                                }
+                            );
                         }
                         catch (Exception)
                         {


### PR DESCRIPTION
Changes to chart reloads have broken downloading to where the user has to press the download button more than once. This should alleviate those issues.

(See TootTally/TootTallyCore#11 for more info)